### PR TITLE
fix(loader): compare constructors instead of prototypes

### DIFF
--- a/src/lib/strategies/Shared.ts
+++ b/src/lib/strategies/Shared.ts
@@ -28,7 +28,7 @@ export function isClass(value: unknown): value is Ctor {
 export function classExtends<T extends Ctor>(value: Ctor, base: T): value is T {
 	let ctor: Ctor | null = value;
 	while (ctor !== null) {
-		if (ctor === base) return true;
+		if (ctor.constructor === base.constructor) return true;
 		ctor = Object.getPrototypeOf(ctor);
 	}
 


### PR DESCRIPTION
Why did the previous code work PERFECTLY FINE when run with Node.js, but BORKED in debugger, is something I don't understand.

Nevertheless...

![image](https://user-images.githubusercontent.com/24852502/103161688-ee897200-47e5-11eb-8f5b-a03dc2465cfa.png)
(RTX ON PIECES, OH YEAH!)